### PR TITLE
Fix color higher than 255

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - hhvm
 
 before_install:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Software License Agreement (The BSD 3-Clause License)
 
-Copyright (c) 2012, Michael K. Squires
+Copyright (c) 2017, Michael K. Squires
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Interested in API docs? You can check out the [Philips API documentation](http:/
 
 ## Requirements
 
-* PHP 5.3+
+* PHP 5.6+
 * cURL extension (optional)
+
+For PHP 5.3 support, please use Phue v1.6.x.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0"
     },
     "require-dev": {
-        "mockery/mockery": "0.8.0",
-        "phpunit/PHPUnit": "3.7.25",
-        "squizlabs/php_codesniffer": "1.4.6"
+        "mockery/mockery": "1.0.0",
+        "phpunit/PHPUnit": "5.7.25",
+        "squizlabs/php_codesniffer": "3.1.1"
     },
     "suggest": {
         "ext-curl": "Allows usage of cURL transport adapter"

--- a/library/Phue/LightModel/Lct001Model.php
+++ b/library/Phue/LightModel/Lct001Model.php
@@ -22,5 +22,5 @@ class Lct001Model extends AbstractLightModel
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19';
+    const MODEL_NAME = 'Hue bulb A19 (gamut B)';
 }

--- a/library/Phue/LightModel/Lct007Model.php
+++ b/library/Phue/LightModel/Lct007Model.php
@@ -22,5 +22,5 @@ class Lct007Model extends AbstractLightModel
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue Bulb V2';
+    const MODEL_NAME = 'Hue bulb A19 (gamut B)';
 }

--- a/library/Phue/LightModel/Lct010Model.php
+++ b/library/Phue/LightModel/Lct010Model.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Phue: Philips Hue PHP Client
+ *
+ * @author    Michael Squires <sqmk@php.net>
+ * @copyright Copyright (c) 2012 Michael K. Squires
+ * @license   http://github.com/sqmk/Phue/wiki/License
+ */
+namespace Phue\LightModel;
+
+/**
+ * Hue Bulb V3
+ */
+class Lct010Model extends AbstractLightModel
+{
+
+    /**
+     * Model id
+     */
+    const MODEL_ID = 'LCT010';
+
+    /**
+     * Model name
+     */
+    const MODEL_NAME = 'Hue Bulb V3';
+}

--- a/library/Phue/LightModel/Lct011Model.php
+++ b/library/Phue/LightModel/Lct011Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue BR30
  */
-class Lct010Model extends AbstractLightModel
+class Lct002Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LCT002';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue BR30';
 }

--- a/library/Phue/LightModel/Lct011Model.php
+++ b/library/Phue/LightModel/Lct011Model.php
@@ -11,13 +11,13 @@ namespace Phue\LightModel;
 /**
  * Hue BR30
  */
-class Lct002Model extends AbstractLightModel
+class Lct011Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT002';
+    const MODEL_ID = 'LCT011';
 
     /**
      * Model name

--- a/library/Phue/LightModel/Lct014Model.php
+++ b/library/Phue/LightModel/Lct014Model.php
@@ -22,5 +22,5 @@ class Lct014Model extends AbstractLightModel
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue Bulb V3';
+    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
 }

--- a/library/Phue/LightModel/Lct014Model.php
+++ b/library/Phue/LightModel/Lct014Model.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Phue: Philips Hue PHP Client
+ *
+ * @author    Michael Squires <sqmk@php.net>
+ * @copyright Copyright (c) 2012 Michael K. Squires
+ * @license   http://github.com/sqmk/Phue/wiki/License
+ */
+namespace Phue\LightModel;
+
+/**
+ * Hue Bulb V3
+ */
+class Lct014Model extends AbstractLightModel
+{
+
+    /**
+     * Model id
+     */
+    const MODEL_ID = 'LCT014';
+
+    /**
+     * Model name
+     */
+    const MODEL_NAME = 'Hue Bulb V3';
+}

--- a/library/Phue/LightModel/Llm010Model.php
+++ b/library/Phue/LightModel/Llm010Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Color Light Module
  */
-class Lct010Model extends AbstractLightModel
+class Llm010Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LLM010';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Color Temperature Module';
 }

--- a/library/Phue/LightModel/Llm011Model.php
+++ b/library/Phue/LightModel/Llm011Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Color Light Module
  */
-class Lct010Model extends AbstractLightModel
+class Llm011Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LLM011';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Color Temperature Module';
 }

--- a/library/Phue/LightModel/Llm012Model.php
+++ b/library/Phue/LightModel/Llm012Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Color Light Module
  */
-class Lct010Model extends AbstractLightModel
+class Llm012Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LLM012';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Color Temperature Module';
 }

--- a/library/Phue/LightModel/Lst002Model.php
+++ b/library/Phue/LightModel/Lst002Model.php
@@ -9,18 +9,23 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue LightStrips
  */
-class Lct010Model extends AbstractLightModel
+class Lst002Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LST002';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue LightStrips Plus';
+
+    /**
+     * Can retain state
+     */
+    const CAN_RETAIN_STATE = true;
 }

--- a/library/Phue/LightModel/Ltw001Model.php
+++ b/library/Phue/LightModel/Ltw001Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue A19 White Ambiance
  */
-class Lct010Model extends AbstractLightModel
+class Ltw001Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LTW001';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue A19 White Ambiance';
 }

--- a/library/Phue/LightModel/Ltw004Model.php
+++ b/library/Phue/LightModel/Ltw004Model.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Phue: Philips Hue PHP Client
+ *
+ * @author    Michael Squires <sqmk@php.net>
+ * @copyright Copyright (c) 2012 Michael K. Squires
+ * @license   http://github.com/sqmk/Phue/wiki/License
+ */
+namespace Phue\LightModel;
+
+/**
+ * Hue A19 White ambiance
+ */
+class Ltw004Model extends AbstractLightModel
+{
+
+    /**
+     * Model id
+     */
+    const MODEL_ID = 'LTW004';
+
+    /**
+     * Model name
+     */
+    const MODEL_NAME = 'Hue A19 White ambiance';
+}

--- a/library/Phue/LightModel/Ltw004Model.php
+++ b/library/Phue/LightModel/Ltw004Model.php
@@ -9,7 +9,7 @@
 namespace Phue\LightModel;
 
 /**
- * Hue A19 White ambiance
+ * Hue A19 White Ambiance
  */
 class Ltw004Model extends AbstractLightModel
 {
@@ -22,5 +22,5 @@ class Ltw004Model extends AbstractLightModel
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue A19 White ambiance';
+    const MODEL_NAME = 'Hue A19 White Ambiance';
 }

--- a/library/Phue/LightModel/Ltw013Model.php
+++ b/library/Phue/LightModel/Ltw013Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue GU-10 White Ambiance
  */
-class Lct010Model extends AbstractLightModel
+class Ltw013Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LTW013';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue GU-10 White Ambiance';
 }

--- a/library/Phue/LightModel/Ltw014Model.php
+++ b/library/Phue/LightModel/Ltw014Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue GU-10 White Ambiance
  */
-class Lct010Model extends AbstractLightModel
+class Ltw014Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LTW014';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue GU-10 White Ambiance';
 }

--- a/library/Phue/LightModel/Lwb007Model.php
+++ b/library/Phue/LightModel/Lwb007Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue A19 Lux
  */
-class Lct010Model extends AbstractLightModel
+class Lwb007Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LWB007';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue A19 Lux';
 }

--- a/library/Phue/LightModel/Lwb010Model.php
+++ b/library/Phue/LightModel/Lwb010Model.php
@@ -9,18 +9,18 @@
 namespace Phue\LightModel;
 
 /**
- * Hue Bulb V3
+ * Hue A19 Lux
  */
-class Lct010Model extends AbstractLightModel
+class Lwb010Model extends AbstractLightModel
 {
 
     /**
      * Model id
      */
-    const MODEL_ID = 'LCT010';
+    const MODEL_ID = 'LWB010';
 
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue bulb A19 (gamut C)';
+    const MODEL_NAME = 'Hue A19 Lux';
 }

--- a/library/Phue/LightModel/Lwb014Model.php
+++ b/library/Phue/LightModel/Lwb014Model.php
@@ -9,7 +9,7 @@
 namespace Phue\LightModel;
 
 /**
- * Hue A19 White
+ * Hue A19 Lux
  */
 class Lwb014Model extends AbstractLightModel
 {
@@ -22,5 +22,5 @@ class Lwb014Model extends AbstractLightModel
     /**
      * Model name
      */
-    const MODEL_NAME = 'Hue A19 White';
+    const MODEL_NAME = 'Hue A19 Lux';
 }

--- a/library/Phue/LightModel/Lwb014Model.php
+++ b/library/Phue/LightModel/Lwb014Model.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Phue: Philips Hue PHP Client
+ *
+ * @author    Michael Squires <sqmk@php.net>
+ * @copyright Copyright (c) 2012 Michael K. Squires
+ * @license   http://github.com/sqmk/Phue/wiki/License
+ */
+namespace Phue\LightModel;
+
+/**
+ * Hue A19 White
+ */
+class Lwb014Model extends AbstractLightModel
+{
+
+    /**
+     * Model id
+     */
+    const MODEL_ID = 'LWB014';
+
+    /**
+     * Model name
+     */
+    const MODEL_NAME = 'Hue A19 White';
+}

--- a/library/Phue/Transport/Http.php
+++ b/library/Phue/Transport/Http.php
@@ -227,7 +227,7 @@ class Http implements TransportInterface
         $contentType = $this->getAdapter()->getContentType();
         
         // Throw connection exception if status code isn't 200 or wrong content type
-        if ($status != 200 || $contentType != 'application/json') {
+        if ($status != 200 || substr($contentType, 0, strpos($contentType, ';')) != 'application/json') {
             throw new ConnectionException('Connection failure');
         }
         

--- a/library/Phue/Transport/Http.php
+++ b/library/Phue/Transport/Http.php
@@ -227,7 +227,7 @@ class Http implements TransportInterface
         $contentType = $this->getAdapter()->getContentType();
         
         // Throw connection exception if status code isn't 200 or wrong content type
-        if ($status != 200 || substr($contentType, 0, strpos($contentType, ';')) != 'application/json') {
+        if ($status != 200 || explode(';', $contentType)[0] != 'application/json') {
             throw new ConnectionException('Connection failure');
         }
         

--- a/library/Phue/Transport/TransportInterface.php
+++ b/library/Phue/Transport/TransportInterface.php
@@ -37,14 +37,22 @@ interface TransportInterface
     /**
      * Send request
      *
-     * @param string $path
-     *            API path
-     * @param string $method
-     *            Request method
-     * @param \stdClass $data
-     *            Body data
+     * @param string $address API path
+     * @param string $method Request method
+     * @param \stdClass $body Body data
      *
      * @return mixed Command result
      */
-    public function sendRequest($path, $method = self::METHOD_GET, \stdClass $data = null);
+    public function sendRequest($address, $method = self::METHOD_GET, \stdClass $body = null);
+
+    /**
+     * Send request, bypass body validation
+     *
+     * @param string $address API path
+     * @param string $method Request method
+     * @param \stdClass $body Body data
+     *
+     * @return mixed Command result
+     */
+    public function sendRequestBypassBodyValidation($address, $method = self::METHOD_GET, \stdClass $body = null);
 }

--- a/tests/Phue/Test/BridgeTest.php
+++ b/tests/Phue/Test/BridgeTest.php
@@ -23,7 +23,7 @@ class BridgeTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/ClientTest.php
+++ b/tests/Phue/Test/ClientTest.php
@@ -62,7 +62,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetBridge()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -87,7 +87,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetUsers()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -127,7 +127,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetLights()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -168,7 +168,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetGroups()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -209,7 +209,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetSchedules()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -247,7 +247,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetScenes()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -290,7 +290,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetSensors()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -327,7 +327,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetRules()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -364,7 +364,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetTimezones()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest',
                 'sendRequestBypassBodyValidation'
@@ -409,7 +409,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testPassingTransportDependency()
     {
         // Mock transport
-        $mockTransport = $this->getMock('\Phue\Transport\TransportInterface');
+        $mockTransport = $this->createMock('\Phue\Transport\TransportInterface');
         
         $this->client->setTransport($mockTransport);
         
@@ -424,7 +424,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testSendCommand()
     {
         // Mock command
-        $mockCommand = $this->getMock('Phue\Command\CommandInterface', 
+        $mockCommand = $this->createMock('Phue\Command\CommandInterface', 
             array(
                 'send'
             ));

--- a/tests/Phue/Test/Command/CreateGroupTest.php
+++ b/tests/Phue/Test/Command/CreateGroupTest.php
@@ -24,7 +24,7 @@ class CreateGroupTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class CreateGroupTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/CreateSceneTest.php
+++ b/tests/Phue/Test/Command/CreateSceneTest.php
@@ -24,7 +24,7 @@ class CreateSceneTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class CreateSceneTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/CreateScheduleTest.php
+++ b/tests/Phue/Test/Command/CreateScheduleTest.php
@@ -28,7 +28,7 @@ class CreateScheduleTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set('UTC');
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -37,7 +37,7 @@ class CreateScheduleTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -53,7 +53,7 @@ class CreateScheduleTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->mockTransport));
         
         // Mock actionable command
-        $this->mockCommand = $this->getMock('\Phue\Command\ActionableInterface', 
+        $this->mockCommand = $this->createMock('\Phue\Command\ActionableInterface', 
             array(
                 'getActionableParams'
             ));

--- a/tests/Phue/Test/Command/CreateUserTest.php
+++ b/tests/Phue/Test/Command/CreateUserTest.php
@@ -24,7 +24,7 @@ class CreateUserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class CreateUserTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/DeleteGroupTest.php
+++ b/tests/Phue/Test/Command/DeleteGroupTest.php
@@ -24,7 +24,7 @@ class DeleteGroupTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class DeleteGroupTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/DeleteRuleTest.php
+++ b/tests/Phue/Test/Command/DeleteRuleTest.php
@@ -24,7 +24,7 @@ class DeleteRuleTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class DeleteRuleTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/DeleteScheduleTest.php
+++ b/tests/Phue/Test/Command/DeleteScheduleTest.php
@@ -24,7 +24,7 @@ class DeleteScheduleTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class DeleteScheduleTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/DeleteUserTest.php
+++ b/tests/Phue/Test/Command/DeleteUserTest.php
@@ -24,7 +24,7 @@ class DeleteUserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class DeleteUserTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetBridgeTest.php
+++ b/tests/Phue/Test/Command/GetBridgeTest.php
@@ -26,7 +26,7 @@ class GetBridgeTest extends \PHPUnit_Framework_TestCase
         $this->getBridge = new GetBridge();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetBridgeTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetGroupByIdTest.php
+++ b/tests/Phue/Test/Command/GetGroupByIdTest.php
@@ -24,7 +24,7 @@ class GetGroupByIdTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class GetGroupByIdTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetGroupsTest.php
+++ b/tests/Phue/Test/Command/GetGroupsTest.php
@@ -26,7 +26,7 @@ class GetGroupsTest extends \PHPUnit_Framework_TestCase
         $this->getGroups = new GetGroups();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetGroupsTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetLightByIdTest.php
+++ b/tests/Phue/Test/Command/GetLightByIdTest.php
@@ -24,7 +24,7 @@ class GetLightByIdTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -33,7 +33,7 @@ class GetLightByIdTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetLightsTest.php
+++ b/tests/Phue/Test/Command/GetLightsTest.php
@@ -26,7 +26,7 @@ class GetLightsTest extends \PHPUnit_Framework_TestCase
         $this->getLights = new GetLights();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetLightsTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetNewLightsTest.php
+++ b/tests/Phue/Test/Command/GetNewLightsTest.php
@@ -26,7 +26,7 @@ class GetNewLightsTest extends \PHPUnit_Framework_TestCase
         $this->getNewLights = new GetNewLights();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetNewLightsTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetNewSensorsTest.php
+++ b/tests/Phue/Test/Command/GetNewSensorsTest.php
@@ -26,7 +26,7 @@ class GetNewSensorsTest extends \PHPUnit_Framework_TestCase
         $this->getNewSensors = new GetNewSensors();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetNewSensorsTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetRulesTest.php
+++ b/tests/Phue/Test/Command/GetRulesTest.php
@@ -26,7 +26,7 @@ class GetRulesTest extends \PHPUnit_Framework_TestCase
         $this->getRules = new GetRules();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetRulesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetScenesTest.php
+++ b/tests/Phue/Test/Command/GetScenesTest.php
@@ -26,7 +26,7 @@ class GetScenesTest extends \PHPUnit_Framework_TestCase
         $this->getScenes = new GetScenes();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetScenesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetScheduleByIdTest.php
+++ b/tests/Phue/Test/Command/GetScheduleByIdTest.php
@@ -24,7 +24,7 @@ class GetScheduleByIdTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,7 +32,7 @@ class GetScheduleByIdTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetSchedulesTest.php
+++ b/tests/Phue/Test/Command/GetSchedulesTest.php
@@ -26,7 +26,7 @@ class GetSchedulesTest extends \PHPUnit_Framework_TestCase
         $this->getSchedules = new GetSchedules();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetSchedulesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetSensorsTest.php
+++ b/tests/Phue/Test/Command/GetSensorsTest.php
@@ -26,7 +26,7 @@ class GetSensorsTest extends \PHPUnit_Framework_TestCase
         $this->getSensors = new GetSensors();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetSensorsTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/GetTimezonesTest.php
+++ b/tests/Phue/Test/Command/GetTimezonesTest.php
@@ -26,7 +26,7 @@ class GetTimezonesTest extends \PHPUnit_Framework_TestCase
         $this->getTimezones = new GetTimezones();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetTimezonesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest',
                 'sendRequestBypassBodyValidation'

--- a/tests/Phue/Test/Command/GetUsersTest.php
+++ b/tests/Phue/Test/Command/GetUsersTest.php
@@ -26,7 +26,7 @@ class GetUsersTest extends \PHPUnit_Framework_TestCase
         $this->getUsers = new GetUsers();
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getUsername',
                 'getTransport'
@@ -35,7 +35,7 @@ class GetUsersTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/IsAuthorizedTest.php
+++ b/tests/Phue/Test/Command/IsAuthorizedTest.php
@@ -25,7 +25,7 @@ class IsAuthorizedTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -33,7 +33,7 @@ class IsAuthorizedTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
@@ -76,9 +76,9 @@ class IsAuthorizedTest extends \PHPUnit_Framework_TestCase
         $this->mockTransport->expects($this->once())
             ->method('sendRequest')
             ->with($this->equalTo("/api/{$this->mockClient->getUsername()}"))
-            ->will(
-            $this->throwException(
-                $this->getMock('\Phue\Transport\Exception\UnauthorizedUserException')));
+            ->will($this->throwException(
+                $this->createMock('\Phue\Transport\Exception\UnauthorizedUserException')
+            ));
         
         $auth = new IsAuthorized();
         $this->assertFalse($auth->send($this->mockClient));

--- a/tests/Phue/Test/Command/PingTest.php
+++ b/tests/Phue/Test/Command/PingTest.php
@@ -24,7 +24,7 @@ class PingTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,7 +32,7 @@ class PingTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/SetBridgeConfigTest.php
+++ b/tests/Phue/Test/Command/SetBridgeConfigTest.php
@@ -24,7 +24,7 @@ class SetBridgeConfigTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,7 +32,7 @@ class SetBridgeConfigTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/SetGroupAttributesTest.php
+++ b/tests/Phue/Test/Command/SetGroupAttributesTest.php
@@ -24,7 +24,7 @@ class SetGroupAttributesTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,13 +32,13 @@ class SetGroupAttributesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock group
-        $this->mockGroup = $this->getMock('\Phue\Group', null, 
+        $this->mockGroup = $this->createMock('\Phue\Group', null, 
             array(
                 2,
                 new \stdClass(),

--- a/tests/Phue/Test/Command/SetGroupStateTest.php
+++ b/tests/Phue/Test/Command/SetGroupStateTest.php
@@ -24,7 +24,7 @@ class SetGroupStateTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,13 +32,13 @@ class SetGroupStateTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock group
-        $this->mockGroup = $this->getMock('\Phue\Group', null, 
+        $this->mockGroup = $this->createMock('\Phue\Group', null, 
             array(
                 2,
                 new \stdClass(),

--- a/tests/Phue/Test/Command/SetLightNameTest.php
+++ b/tests/Phue/Test/Command/SetLightNameTest.php
@@ -25,7 +25,7 @@ class SetLightNameTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -33,13 +33,13 @@ class SetLightNameTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock light
-        $this->mockLight = $this->getMock('\Phue\Light', null, 
+        $this->mockLight = $this->createMock('\Phue\Light', null, 
             array(
                 3,
                 new \stdClass(),

--- a/tests/Phue/Test/Command/SetLightStateTest.php
+++ b/tests/Phue/Test/Command/SetLightStateTest.php
@@ -25,7 +25,7 @@ class SetLightStateTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -33,13 +33,13 @@ class SetLightStateTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock light
-        $this->mockLight = $this->getMock('\Phue\Light', null, 
+        $this->mockLight = $this->createMock('\Phue\Light', null, 
             array(
                 3,
                 new \stdClass(),

--- a/tests/Phue/Test/Command/SetSceneLightStateTest.php
+++ b/tests/Phue/Test/Command/SetSceneLightStateTest.php
@@ -24,7 +24,7 @@ class SetSceneLightStateTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,13 +32,13 @@ class SetSceneLightStateTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock scene
-        $this->mockScene = $this->getMock('\Phue\Scene', null, 
+        $this->mockScene = $this->createMock('\Phue\Scene', null, 
             array(
                 'phue-test',
                 new \stdClass(),
@@ -46,7 +46,7 @@ class SetSceneLightStateTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock light
-        $this->mockLight = $this->getMock('\Phue\Light', null, 
+        $this->mockLight = $this->createMock('\Phue\Light', null, 
             array(
                 3,
                 new \stdClass(),

--- a/tests/Phue/Test/Command/SetScheduleAttributesTest.php
+++ b/tests/Phue/Test/Command/SetScheduleAttributesTest.php
@@ -24,7 +24,7 @@ class SetScheduleAttributesTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,13 +32,13 @@ class SetScheduleAttributesTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));
         
         // Mock schedule
-        $this->mockSchedule = $this->getMock('\Phue\Schedule', null, 
+        $this->mockSchedule = $this->createMock('\Phue\Schedule', null, 
             array(
                 12,
                 new \stdClass(),
@@ -56,7 +56,7 @@ class SetScheduleAttributesTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->mockTransport));
         
         // Mock actionable command
-        $this->mockCommand = $this->getMock('\Phue\Command\ActionableInterface', 
+        $this->mockCommand = $this->createMock('\Phue\Command\ActionableInterface', 
             array(
                 'getActionableParams'
             ));

--- a/tests/Phue/Test/Command/StartLightScanTest.php
+++ b/tests/Phue/Test/Command/StartLightScanTest.php
@@ -24,7 +24,7 @@ class StartLightScanTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,7 +32,7 @@ class StartLightScanTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/Command/StartSensorScanTest.php
+++ b/tests/Phue/Test/Command/StartSensorScanTest.php
@@ -24,7 +24,7 @@ class StartSensorScanTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'getTransport'
             ), array(
@@ -32,7 +32,7 @@ class StartSensorScanTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport
-        $this->mockTransport = $this->getMock('\Phue\Transport\TransportInterface', 
+        $this->mockTransport = $this->createMock('\Phue\Transport\TransportInterface', 
             array(
                 'sendRequest'
             ));

--- a/tests/Phue/Test/GroupTest.php
+++ b/tests/Phue/Test/GroupTest.php
@@ -24,9 +24,7 @@ class GroupTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
-            // ['sendCommand'],
-            // ['127.0.0.1']
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(
@@ -34,21 +32,6 @@ class GroupTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Build stub attributes
-        // $this->attributes = (object) [
-        // 'name' => 'Dummy group',
-        // 'action' => (object) [
-        // 'on' => false,
-        // 'bri' => '66',
-        // 'hue' => '60123',
-        // 'sat' => 213,
-        // 'xy' => [0.5, 0.4],
-        // 'ct' => 300,
-        // 'colormode' => 'hs',
-        // 'effect' => 'none',
-        // ],
-        // 'lights' => [2, 3, 5],
-        // 'type' => 'LightGroup',
-        // ];
         $this->attributes = (object) array(
             'name' => 'Dummy group',
             'action' => (object) array(

--- a/tests/Phue/Test/LightTest.php
+++ b/tests/Phue/Test/LightTest.php
@@ -23,7 +23,7 @@ class LightTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             // ['sendCommand'],
             // ['127.0.0.1']
             array(

--- a/tests/Phue/Test/PortalTest.php
+++ b/tests/Phue/Test/PortalTest.php
@@ -25,7 +25,7 @@ class PortalTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/RuleTest.php
+++ b/tests/Phue/Test/RuleTest.php
@@ -25,7 +25,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/SceneTest.php
+++ b/tests/Phue/Test/SceneTest.php
@@ -25,7 +25,7 @@ class SceneTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/ScheduleTest.php
+++ b/tests/Phue/Test/ScheduleTest.php
@@ -26,7 +26,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set('UTC');
         
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(
@@ -187,7 +187,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->schedule));
         
         // Mock actionable command
-        $mockCommand = $this->getMock('\Phue\Command\ActionableInterface', 
+        $mockCommand = $this->createMock('\Phue\Command\ActionableInterface', 
             array(
                 'getActionableParams'
             ));

--- a/tests/Phue/Test/SensorTest.php
+++ b/tests/Phue/Test/SensorTest.php
@@ -25,7 +25,7 @@ class SensorTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/SoftwareUpdateTest.php
+++ b/tests/Phue/Test/SoftwareUpdateTest.php
@@ -25,7 +25,7 @@ class SoftwareUpdateTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(

--- a/tests/Phue/Test/Transport/HttpTest.php
+++ b/tests/Phue/Test/Transport/HttpTest.php
@@ -22,7 +22,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             // ['getTransport'],
             // ['127.0.0.1']
             array(
@@ -32,7 +32,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             ));
         
         // Mock transport adapter
-        $this->mockAdapter = $this->getMock(
+        $this->mockAdapter = $this->createMock(
             '\Phue\Transport\Adapter\AdapterInterface');
         
         // Set transport

--- a/tests/Phue/Test/UserTest.php
+++ b/tests/Phue/Test/UserTest.php
@@ -23,7 +23,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Mock client
-        $this->mockClient = $this->getMock('\Phue\Client', 
+        $this->mockClient = $this->createMock('\Phue\Client', 
             array(
                 'sendCommand'
             ), array(


### PR DESCRIPTION
I had tried to fix colors, more info at : https://github.com/sqmk/Phue/issues/114

```<?php
require_once __DIR__ . '/vendor/autoload.php';

use \Phue\Helper\ColorConversion;

function testConvert($r,$g,$b) {
  $xy = ColorConversion::convertRGBToXY($r,$g,$b);
  
  $rgbConverted = ColorConversion::convertXYToRGB($xy["x"],$xy["y"],$xy["bri"]);
  echo "$r $g $b => {$rgbConverted['red']} {$rgbConverted['green']} {$rgbConverted['blue']}", PHP_EOL;
}

testConvert(255,0,0);
testConvert(200,50,0);
testConvert(200,50,0);
testConvert(243,50,6);
testConvert(200,143,68);
testConvert(233,230,211);
testConvert(33,232,11);
testConvert(2,32,113);
testConvert(98,23,234);
```

The conversion to XY is correct, same as other library excepted ignorance of Gamut of bulb
So i try to convert to XY and back to RGB
and i have these results : 

>>>
255 0 0 => 254 0 0
200 50 0 => 200 50 0
200 50 0 => 200 50 0
243 50 6 => 242 50 6
200 143 68 => 200 143 68
233 230 211 => 233 230 211
33 232 11 => 33 232 11
2 32 113 => 2 34 119
98 23 234 => 97 23 232
>>>